### PR TITLE
Pass cards prop to LaneFooter

### DIFF
--- a/src/controllers/Lane.js
+++ b/src/controllers/Lane.js
@@ -270,7 +270,7 @@ class Lane extends Component {
         {this.renderHeader({id, cards, ...otherProps})}
         {this.renderDragContainer(isDraggingOver)}
         {loading && <components.Loader />}
-        {showFooter && <components.LaneFooter onClick={this.toggleLaneCollapsed} collapsed={collapsed} />}
+        {showFooter && <components.LaneFooter onClick={this.toggleLaneCollapsed} collapsed={collapsed} cards={cards} />}
       </components.Section>
     )
   }

--- a/stories/CustomLaneFooter.story.js
+++ b/stories/CustomLaneFooter.story.js
@@ -5,7 +5,7 @@ import Board from '../src'
 
 const data = require('./data/collapsible.json')
 
-const LaneFooter = ({onClick, collapsed}) => <div onClick={onClick}>{collapsed ? 'click to expand' : 'click to collapse'}</div>
+const LaneFooter = ({onClick, collapsed, cards}) => <div onClick={onClick}>{collapsed ? 'click to expand' : 'click to collapse'} {cards.length} card{cards.length > 1 && 's'}</div>
 
 storiesOf('Custom Components', module).
   add('LaneFooter', () => <Board collapsibleLanes components={{LaneFooter: LaneFooter}} data={data} />)

--- a/tests/__snapshots__/Storyshots.test.js.snap
+++ b/tests/__snapshots__/Storyshots.test.js.snap
@@ -11251,6 +11251,10 @@ Array [
               onClick={[Function]}
             >
               click to collapse
+               
+              4
+               card
+              s
             </div>
           </section>
           <section
@@ -11337,6 +11341,9 @@ Array [
               onClick={[Function]}
             >
               click to collapse
+               
+              1
+               card
             </div>
           </section>
           <section
@@ -11503,6 +11510,10 @@ Array [
               onClick={[Function]}
             >
               click to collapse
+               
+              2
+               card
+              s
             </div>
           </section>
           <section
@@ -11589,6 +11600,9 @@ Array [
               onClick={[Function]}
             >
               click to collapse
+               
+              1
+               card
             </div>
           </section>
           <section
@@ -11675,6 +11689,9 @@ Array [
               onClick={[Function]}
             >
               click to collapse
+               
+              1
+               card
             </div>
           </section>
           <section
@@ -11761,6 +11778,9 @@ Array [
               onClick={[Function]}
             >
               click to collapse
+               
+              1
+               card
             </div>
           </section>
           <section
@@ -11847,6 +11867,9 @@ Array [
               onClick={[Function]}
             >
               click to collapse
+               
+              1
+               card
             </div>
           </section>
         </div>


### PR DESCRIPTION
Add cards prop to LaneFooter, so it will be possible to show various info based on a lane cards in custom footers. I specifically need to show a number of cards inside the footer.